### PR TITLE
Fix typo on an import.

### DIFF
--- a/src/main/java/net/andrewhatch/coin/wallet/recovery/RecoverService.java
+++ b/src/main/java/net/andrewhatch/coin/wallet/recovery/RecoverService.java
@@ -1,7 +1,7 @@
 package net.andrewhatch.coin.wallet.recovery;
 
 import info.blockchain.api.APIException;
-import info.blockchain.api.blockexplorer.Address;
+import info.blockchain.api.blockexplorer.entity.Address;
 import info.blockchain.api.blockexplorer.BlockExplorer;
 
 import net.andrewhatch.coin.wallet.Config;


### PR DESCRIPTION
Hi, I downloaded the project but `mvn package` fail so, reading the code in my IDE I found that just was a typo in the import.